### PR TITLE
Added property for ping timeout

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,8 @@ class hornetq::config(
   $rmi_port = undef,
   $min_mem = undef,
   $max_mem = undef,
-  $debug = undef
+  $debug = undef,
+  $pingtimeout = 30
 ){
 
   validate_re($version, '^[~+._0-9a-zA-Z:-]+$')

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,7 @@ class hornetq::config(
   $min_mem = undef,
   $max_mem = undef,
   $debug = undef,
-  $pingtimeout = 30
+  $ping_timeout = undef
 ){
 
   validate_re($version, '^[~+._0-9a-zA-Z:-]+$')

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class hornetq(
   $min_mem = '512',
   $max_mem = '1024',
   $debug = 'FALSE',
+  $ping_timeout = '30'
 ){
 
   include stdlib
@@ -53,7 +54,8 @@ class hornetq(
     rmi_port      => $rmi_port,
     min_mem       => $min_mem,
     max_mem       => $max_mem,
-    debug         => $debug
+    debug         => $debug,
+    ping_timeout   => $ping_timeout
   }
 
   class { 'hornetq::service':

--- a/templates/etc/hornetq/hornetq-wrapper.conf.erb
+++ b/templates/etc/hornetq/hornetq-wrapper.conf.erb
@@ -226,3 +226,7 @@ wrapper.ntservice.starttype=AUTO_START
 
 # Allow the service to interact with the desktop.
 wrapper.ntservice.interactive=false
+
+# Time to wait until Tanuki kills the JVM process
+# See https://confluence.atlassian.com/pages/viewpage.action?pageId=186712400
+wrapper.ping.timeout=<%= @pingtimeout %>

--- a/templates/etc/hornetq/hornetq-wrapper.conf.erb
+++ b/templates/etc/hornetq/hornetq-wrapper.conf.erb
@@ -229,4 +229,4 @@ wrapper.ntservice.interactive=false
 
 # Time to wait until Tanuki kills the JVM process
 # See https://confluence.atlassian.com/pages/viewpage.action?pageId=186712400
-wrapper.ping.timeout=<%= @pingtimeout %>
+wrapper.ping.timeout=<%= @ping_timeout %>


### PR DESCRIPTION
Look out when merging this pull request, because we don't want Puppet Master to automatically restart all HornetQ services.

Default of 30 we got from Tanuki's documentation on this property, so it's also the default for Tanuki itself if you don't specify this property.
